### PR TITLE
Add MCP documentation section

### DIFF
--- a/content/en/docs/mcp/_index.md
+++ b/content/en/docs/mcp/_index.md
@@ -1,0 +1,75 @@
+---
+title: "MCP"
+linkTitle: "MCP"
+description: "Connect AI assistants and coding agents to your Trustgrid infrastructure using the Model Context Protocol."
+---
+
+The Trustgrid MCP server lets AI assistants — Claude, Copilot, Cursor, and others — interact with your Trustgrid environment using natural language. Ask questions about node status, run network diagnostics, query alerts, and explore your topology without leaving your editor or chat interface.
+
+## What you can do
+
+> **⚠️ Read-only access**  
+> The MCP server provides read-only access to your Trustgrid infrastructure. No changes can be made through the MCP interface at this time.
+
+- **Query infrastructure** — list nodes, inspect configuration, check VPN routes, review certificates and policies
+- **Run live diagnostics** — test TCP connectivity, DNS resolution, gateway latency, and packet paths directly on nodes
+- **Explore topology** — understand how your virtual networks, clusters, and gateways are connected
+- **Search documentation** — semantic search across Trustgrid docs returns relevant excerpts alongside live API data
+- **Execute code** (codemode) — run sandboxed JavaScript with full API access for custom analysis and bulk queries
+- **Review audit history** — query config changes, node events, and user activity logs
+
+## Endpoint URL
+
+The MCP server is hosted at `https://mcp.<domain>.trustgrid.io` where `<domain>` matches your organization's Trustgrid domain. For example, if your portal is at `acme.trustgrid.io`, your MCP endpoint is `https://mcp.acme.trustgrid.io`.
+
+The default production endpoint is:
+
+```
+https://mcp.trustgrid.io/mcp/<group>/[<group>...]
+```
+
+The server exposes three tool groups, each at its own path:
+
+| Path | Group | Purpose |
+|---|---|---|
+| `/mcp` or `/mcp/codemode` | codemode | AI sandbox with full read API access |
+| `/mcp/read` | read | Direct read-only API tools |
+| `/mcp/tools` | tools | Live node diagnostic tools |
+| `/mcp/codemode/read` | codemode + read | Both tool sets combined |
+| `/mcp/all` | all | Everything |
+
+You can put any number of suffixes after `/mcp` to combine groups as needed. For example, `/mcp/codemode/tools` gives you both codemode and traditional MCP tools access.
+
+See [Tools]({{<ref "docs/mcp/tools">}}) for details on what each group provides.
+
+## Transport
+
+The Trustgrid MCP server uses **Streamable HTTP transport**. This is the only transport available for external integrations — there is no stdio or WebSocket option. Your MCP client must support HTTP-based MCP connections.
+
+## Authentication
+
+The server accepts two authentication types:
+
+- **OAuth 2.0** - Clients that implement the MCP OAuth handshake (Claude Desktop, Claude Code, and others) will trigger a browser-based login automatically — no manual token needed.
+- **API token** — a `clientId:clientSecret` pair generated in the Trustgrid portal. 
+
+See [Authentication]({{<ref "docs/mcp/authentication">}}) for setup details.
+
+## Rate limits
+
+Requests are rate-limited per request:
+
+| Group | Limit |
+|---|---|
+| codemode | 10 requests / 60 seconds |
+| read | 30 requests / 60 seconds |
+| tools | 10 requests / 60 seconds |
+
+The server returns `429 Too Many Requests` with `Retry-After` and `X-RateLimit-*` headers when limits are exceeded.
+
+## Next steps
+
+- [Authentication]({{<ref "docs/mcp/authentication">}}) — get credentials and understand auth options
+- [Tools]({{<ref "docs/mcp/tools">}}) — explore available tool groups
+- [Installation]({{<ref "docs/mcp/installation">}}) — connect your AI client
+- [Troubleshooting]({{<ref "docs/mcp/troubleshooting">}}) — common setup issues

--- a/content/en/docs/mcp/_index.md
+++ b/content/en/docs/mcp/_index.md
@@ -40,7 +40,7 @@ The server exposes three tool groups, each at its own path:
 
 You can put any number of suffixes after `/mcp` to combine groups as needed. For example, `/mcp/codemode/tools` gives you both codemode and traditional MCP tools access.
 
-See [Tools]({{<ref "docs/mcp/tools">}}) for details on what each group provides.
+See [Tools]({{<relref "docs/mcp/tools" >}}) for details on what each group provides.
 
 ## Transport
 
@@ -53,11 +53,11 @@ The server accepts two authentication types:
 - **OAuth 2.0** - Clients that implement the MCP OAuth handshake (Claude Desktop, Claude Code, and others) will trigger a browser-based login automatically — no manual token needed.
 - **API token** — a `clientId:clientSecret` pair generated in the Trustgrid portal. 
 
-See [Authentication]({{<ref "docs/mcp/authentication">}}) for setup details.
+See [Authentication]({{<relref "docs/mcp/authentication" >}}) for setup details.
 
 ## Rate limits
 
-Requests are rate-limited per request:
+Requests are rate-limited per token:
 
 | Group | Limit |
 |---|---|
@@ -69,7 +69,7 @@ The server returns `429 Too Many Requests` with `Retry-After` and `X-RateLimit-*
 
 ## Next steps
 
-- [Authentication]({{<ref "docs/mcp/authentication">}}) — get credentials and understand auth options
-- [Tools]({{<ref "docs/mcp/tools">}}) — explore available tool groups
-- [Installation]({{<ref "docs/mcp/installation">}}) — connect your AI client
-- [Troubleshooting]({{<ref "docs/mcp/troubleshooting">}}) — common setup issues
+- [Authentication]({{<relref "docs/mcp/authentication" >}}) — get credentials and understand auth options
+- [Tools]({{<relref "docs/mcp/tools" >}}) — explore available tool groups
+- [Installation]({{<relref "docs/mcp/installation" >}}) — connect your AI client
+- [Troubleshooting]({{<relref "docs/mcp/troubleshooting" >}}) — common setup issues

--- a/content/en/docs/mcp/authentication/index.md
+++ b/content/en/docs/mcp/authentication/index.md
@@ -1,7 +1,6 @@
 ---
 title: "Authentication"
 linkTitle: "Authentication"
-weight: 10
 description: "How to authenticate to the Trustgrid MCP server using OAuth or API tokens."
 ---
 

--- a/content/en/docs/mcp/authentication/index.md
+++ b/content/en/docs/mcp/authentication/index.md
@@ -1,0 +1,50 @@
+---
+title: "Authentication"
+linkTitle: "Authentication"
+weight: 10
+description: "How to authenticate to the Trustgrid MCP server using OAuth or API tokens."
+---
+
+The Trustgrid MCP server requires authentication for every request. There are two ways to provide credentials.
+
+## OAuth 2.0
+
+The server implements OAuth 2.0 with the [MCP authorization spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization). Clients that support the OAuth handshake — including Claude Desktop and Claude Code — will automatically open a browser-based login when you first connect. After you authorize, the client manages token refresh without further intervention.
+
+No manual token setup is required for OAuth-capable clients. Just point the client at the MCP URL.
+
+The OAuth authorization server metadata is available at:
+
+```
+https://mcp.<domain>.trustgrid.io/.well-known/oauth-authorization-server
+```
+
+## API token
+
+An API token is a `clientId:clientSecret` pair tied to your Trustgrid user account. It carries the same permissions as your portal account.
+
+**Generate a token:**
+
+1. Log into the Trustgrid portal
+2. Navigate to **User Management** → **API Access**
+3. Click **Generate API keys**
+
+**Use the token:**
+
+Pass the token as an HTTP `Authorization` header using the `trustgrid-token` scheme:
+
+```
+Authorization: trustgrid-token YOUR_CLIENT_ID:YOUR_CLIENT_SECRET
+```
+
+In most MCP client configs, this goes in a `headers` block alongside the server URL.
+
+## Auth error handling
+
+| Response | Meaning | Fix |
+|---|---|---|
+| `401 Unauthorized` | Missing or malformed `Authorization` header | Check that the header is present and correctly formatted |
+| `401` with `WWW-Authenticate` header | Server is requesting OAuth | Your client should initiate the OAuth flow; if it doesn't, provide a static token instead |
+| `403 Forbidden` | Token is valid but lacks required scope | The credential doesn't have permission for the requested operation — check API key permissions or generate a new key |
+
+If you see a `WWW-Authenticate` challenge with a `resource_metadata` URL and your client doesn't handle OAuth, you need to provide a static API token or JWT directly in the config header.

--- a/content/en/docs/mcp/installation/index.md
+++ b/content/en/docs/mcp/installation/index.md
@@ -1,0 +1,314 @@
+---
+title: "Installation"
+linkTitle: "Installation"
+weight: 30
+description: "How to configure the Trustgrid MCP server in Claude, Cursor, VS Code, Copilot, and other AI clients."
+---
+
+## Before you start
+
+You need two things:
+
+1. **Your MCP endpoint URL** — `https://mcp.<domain>.trustgrid.io/mcp` where `<domain>` matches your Trustgrid organization. The default is `https://mcp.trustgrid.io/mcp`. The path suffix selects the [tool group]({{<ref "docs/mcp/tools">}}): `/mcp/codemode` (codemode), `/mcp/read`, `/mcp/tools`, or a combination like `/mcp/codemode/read`.
+
+2. **Credentials** — OAuth is the preferred method: if your client supports it, point it at the URL and it will handle login automatically — no token management required. For clients that don't support OAuth, generate an API token (`clientId:clientSecret`) from **User Management** → **API Access** in the portal. See [Authentication]({{<ref "docs/mcp/authentication">}}).
+
+Examples below use `https://mcp.trustgrid.io/mcp/codemode` as the URL. OAuth examples are shown first where supported; API token examples follow as a fallback. Replace URLs and credentials with your actual values.
+
+---
+
+## Claude Desktop
+
+Claude Desktop supports OAuth. Edit the config file and omit the `headers` block — it will open a browser login on first connection:
+
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "trustgrid": {
+      "type": "http",
+      "url": "https://mcp.trustgrid.io/mcp"
+    }
+  }
+}
+```
+
+If you prefer an API token instead, add a `headers` block:
+
+```json
+{
+  "mcpServers": {
+    "trustgrid": {
+      "type": "http",
+      "url": "https://mcp.trustgrid.io/mcp",
+      "headers": {
+        "Authorization": "trustgrid-token YOUR_CLIENT_ID:YOUR_CLIENT_SECRET"
+      }
+    }
+  }
+}
+```
+
+Restart Claude Desktop after saving the config. The Trustgrid tools will appear in the tool selector.
+
+---
+
+## Claude Code
+
+Claude Code supports OAuth. This is the recommended setup — it will prompt for browser authorization on first use:
+
+```bash
+claude mcp add --transport http trustgrid https://mcp.trustgrid.io/mcp
+```
+
+If you prefer an API token, pass the header explicitly:
+
+```bash
+claude mcp add --transport http trustgrid https://mcp.trustgrid.io/mcp/codemode \
+  --header "Authorization: trustgrid-token YOUR_CLIENT_ID:YOUR_CLIENT_SECRET"
+```
+
+Or add the API token directly in `~/.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "trustgrid": {
+      "type": "http",
+      "url": "https://mcp.trustgrid.io/mcp/codemode",
+      "headers": {
+        "Authorization": "trustgrid-token YOUR_CLIENT_ID:YOUR_CLIENT_SECRET"
+      }
+    }
+  }
+}
+```
+
+---
+
+## GitHub Copilot (VS Code)
+
+VS Code supports OAuth for MCP servers. Open or create `.vscode/mcp.json` in your workspace (for project-scoped access) or use your VS Code user settings for global access. Omitting the `headers` block will trigger OAuth login on first use.
+
+**Workspace (`.vscode/mcp.json`) — OAuth:**
+
+```json
+{
+  "servers": {
+    "trustgrid": {
+      "type": "http",
+      "url": "https://mcp.trustgrid.io/mcp/codemode"
+    }
+  }
+}
+```
+
+**User settings (`settings.json`) — OAuth:**
+
+```json
+{
+  "mcp.servers": {
+    "trustgrid": {
+      "type": "http",
+      "url": "https://mcp.trustgrid.io/mcp/codemode"
+    }
+  }
+}
+```
+
+If you prefer an API token, add a `headers` block to either config:
+
+```json
+"headers": {
+  "Authorization": "trustgrid-token YOUR_CLIENT_ID:YOUR_CLIENT_SECRET"
+}
+```
+
+MCP tool use in VS Code requires Copilot Chat in agent mode. Open Copilot Chat, switch to **Agent** mode, and Trustgrid tools will be available.
+
+---
+
+## Cursor
+
+Cursor supports OAuth for remote MCP servers. Create or edit `.cursor/mcp.json` in your workspace, or `~/.cursor/mcp.json` for global access. Omit `headers` and Cursor will handle OAuth automatically via dynamic client registration:
+
+```json
+{
+  "mcpServers": {
+    "trustgrid": {
+      "url": "https://mcp.trustgrid.io/mcp/codemode"
+    }
+  }
+}
+```
+
+If you prefer an API token, add a `headers` block:
+
+```json
+{
+  "mcpServers": {
+    "trustgrid": {
+      "url": "https://mcp.trustgrid.io/mcp/codemode",
+      "headers": {
+        "Authorization": "trustgrid-token YOUR_CLIENT_ID:YOUR_CLIENT_SECRET"
+      }
+    }
+  }
+}
+```
+
+Cursor detects MCP servers automatically from this file. No restart required — open Cursor's chat panel and the Trustgrid tools will appear.
+
+---
+
+## Windsurf
+
+Windsurf supports OAuth for all MCP transport types. Edit `~/.codeium/windsurf/mcp_config.json` and omit `headers` to use OAuth:
+
+```json
+{
+  "mcpServers": {
+    "trustgrid": {
+      "serverUrl": "https://mcp.trustgrid.io/mcp/codemode"
+    }
+  }
+}
+```
+
+If you prefer an API token, add a `headers` block:
+
+```json
+{
+  "mcpServers": {
+    "trustgrid": {
+      "serverUrl": "https://mcp.trustgrid.io/mcp/codemode",
+      "headers": {
+        "Authorization": "trustgrid-token YOUR_CLIENT_ID:YOUR_CLIENT_SECRET"
+      }
+    }
+  }
+}
+```
+
+Restart Windsurf after saving. Trustgrid tools will be available in the Cascade panel.
+
+---
+
+## opencode
+
+opencode supports OAuth with automatic detection. Edit `~/.config/opencode/opencode.json` and omit `headers` — if the server requires authentication, opencode will prompt you to authorize in your browser:
+
+```json
+{
+  "mcp": {
+    "trustgrid": {
+      "type": "remote",
+      "enabled": true,
+      "url": "https://mcp.trustgrid.io/mcp/codemode"
+    }
+  }
+}
+```
+
+You can also trigger auth manually: `opencode mcp auth trustgrid`
+
+If you prefer an API token, add a `headers` block:
+
+```json
+{
+  "mcp": {
+    "trustgrid": {
+      "type": "remote",
+      "enabled": true,
+      "url": "https://mcp.trustgrid.io/mcp/codemode",
+      "headers": {
+        "Authorization": "trustgrid-token YOUR_CLIENT_ID:YOUR_CLIENT_SECRET"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Codex (OpenAI CLI)
+
+Codex supports OAuth. Add the server URL to `~/.codex/config.toml`, then run `codex mcp login trustgrid` to complete the OAuth flow:
+
+```toml
+[mcp_servers.trustgrid]
+url = "https://mcp.trustgrid.io/mcp/codemode"
+```
+
+If you prefer an API token, add the header to the config instead:
+
+```toml
+[mcp_servers.trustgrid]
+url = "https://mcp.trustgrid.io/mcp/codemode"
+
+[mcp_servers.trustgrid.http_headers]
+Authorization = "trustgrid-token YOUR_CLIENT_ID:YOUR_CLIENT_SECRET"
+```
+
+Or pass via CLI flag:
+
+```bash
+codex --mcp-server 'trustgrid=https://mcp.trustgrid.io/mcp/codemode' \
+  --mcp-header 'Authorization: trustgrid-token YOUR_CLIENT_ID:YOUR_CLIENT_SECRET' \
+  "List all offline nodes"
+```
+
+---
+
+## Kiro
+
+Kiro does not currently support OAuth for MCP servers. Use an API token. Create or edit the MCP config in your Kiro workspace settings:
+
+```json
+{
+  "mcpServers": {
+    "trustgrid": {
+      "type": "http",
+      "url": "https://mcp.trustgrid.io/mcp/codemode",
+      "headers": {
+        "Authorization": "trustgrid-token YOUR_CLIENT_ID:YOUR_CLIENT_SECRET"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Antigravity
+
+Add the server in Antigravity's MCP configuration. Check Antigravity's docs for OAuth support — if supported, omit the `headers` block. Otherwise use an API token:
+
+```json
+{
+  "mcpServers": {
+    "trustgrid": {
+      "type": "http",
+      "url": "https://mcp.trustgrid.io/mcp/codemode",
+      "headers": {
+        "Authorization": "trustgrid-token YOUR_CLIENT_ID:YOUR_CLIENT_SECRET"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Generic / other clients
+
+Any MCP client that supports Streamable HTTP transport can connect to the Trustgrid MCP server. If your client supports OAuth 2.0 discovery, that's the preferred approach — point it at the URL and it will negotiate auth automatically via the `/.well-known/oauth-authorization-server` metadata endpoint. For clients that don't support OAuth, pass the `Authorization` header directly.
+
+| Setting | Value |
+|---|---|
+| Transport | `http` (Streamable HTTP) |
+| URL | `https://mcp.<domain>.trustgrid.io/mcp/codemode` |
+| Auth (OAuth) | Use `/.well-known/oauth-authorization-server` for discovery |
+| Auth (API token) | `Authorization: trustgrid-token clientId:clientSecret` |

--- a/content/en/docs/mcp/installation/index.md
+++ b/content/en/docs/mcp/installation/index.md
@@ -1,7 +1,6 @@
 ---
 title: "Installation"
 linkTitle: "Installation"
-weight: 30
 description: "How to configure the Trustgrid MCP server in Claude, Cursor, VS Code, Copilot, and other AI clients."
 ---
 
@@ -9,9 +8,9 @@ description: "How to configure the Trustgrid MCP server in Claude, Cursor, VS Co
 
 You need two things:
 
-1. **Your MCP endpoint URL** — `https://mcp.<domain>.trustgrid.io/mcp` where `<domain>` matches your Trustgrid organization. The default is `https://mcp.trustgrid.io/mcp`. The path suffix selects the [tool group]({{<ref "docs/mcp/tools">}}): `/mcp/codemode` (codemode), `/mcp/read`, `/mcp/tools`, or a combination like `/mcp/codemode/read`.
+1. **Your MCP endpoint URL** — `https://mcp.<domain>.trustgrid.io/mcp` where `<domain>` matches your Trustgrid organization. The default is `https://mcp.trustgrid.io/mcp`. The path suffix selects the [tool group]({{<relref "docs/mcp/tools" >}}): `/mcp/codemode` (codemode), `/mcp/read`, `/mcp/tools`, or a combination like `/mcp/codemode/read`.
 
-2. **Credentials** — OAuth is the preferred method: if your client supports it, point it at the URL and it will handle login automatically — no token management required. For clients that don't support OAuth, generate an API token (`clientId:clientSecret`) from **User Management** → **API Access** in the portal. See [Authentication]({{<ref "docs/mcp/authentication">}}).
+2. **Credentials** — OAuth is the preferred method: if your client supports it, point it at the URL and it will handle login automatically — no token management required. For clients that don't support OAuth, generate an API token (`clientId:clientSecret`) from **User Management** → **API Access** in the portal. See [Authentication]({{<relref "docs/mcp/authentication" >}}).
 
 Examples below use `https://mcp.trustgrid.io/mcp/codemode` as the URL. OAuth examples are shown first where supported; API token examples follow as a fallback. Replace URLs and credentials with your actual values.
 

--- a/content/en/docs/mcp/installation/index.md
+++ b/content/en/docs/mcp/installation/index.md
@@ -8,7 +8,7 @@ description: "How to configure the Trustgrid MCP server in Claude, Cursor, VS Co
 
 You need two things:
 
-1. **Your MCP endpoint URL** — `https://mcp.<domain>.trustgrid.io/mcp` where `<domain>` matches your Trustgrid organization. The default is `https://mcp.trustgrid.io/mcp`. The path suffix selects the [tool group]({{<relref "docs/mcp/tools" >}}): `/mcp/codemode` (codemode), `/mcp/read`, `/mcp/tools`, or a combination like `/mcp/codemode/read`.
+1. **Your MCP endpoint URL** — The default is `https://mcp.trustgrid.io/mcp`. If your organization uses a tenant-specific portal domain (for example, `acme.trustgrid.io`), use `https://mcp.acme.trustgrid.io/mcp` instead. The path suffix selects the [tool group]({{<relref "docs/mcp/tools" >}}): `/mcp/codemode` (codemode), `/mcp/read`, `/mcp/tools`, or a combination like `/mcp/codemode/read`.
 
 2. **Credentials** — OAuth is the preferred method: if your client supports it, point it at the URL and it will handle login automatically — no token management required. For clients that don't support OAuth, generate an API token (`clientId:clientSecret`) from **User Management** → **API Access** in the portal. See [Authentication]({{<relref "docs/mcp/authentication" >}}).
 

--- a/content/en/docs/mcp/tools/index.md
+++ b/content/en/docs/mcp/tools/index.md
@@ -1,0 +1,94 @@
+---
+title: "Available Tools"
+linkTitle: "Tools"
+weight: 20
+description: "Tool groups exposed by the Trustgrid MCP server and what each tool does."
+---
+
+The Trustgrid MCP server organizes its tools into three groups. Each group is available at a distinct URL path, and paths can be combined to get the union of multiple groups.
+
+## Tool groups
+
+### codemode (`/mcp/codemode`)
+
+The codemode group is the default when no path suffix is specified. It provides an AI code execution sandbox with full read-only access to the Trustgrid API, plus documentation search and structured resource inspection. This reduces token usage and agent turns, and allows your agent to perform complex multi-step reasoning and data retrieval in a deterministic single turn — without needing to switch back and forth between tools.
+
+| Tool       | Description                                                                                                                           |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `search`   | Semantic and keyword search across Trustgrid documentation. Returns relevant excerpts with source links.                              |
+| `describe` | Describe a codemode function. This provide the full signature to help your agent write valid code.                                    |
+| `code`     | Execute sandboxed JavaScript with access to the full read-only Trustgrid API. Use for custom queries, aggregations, and bulk lookups. |
+| `followUp` | Paginate through results from a prior `code` or `search` call.                                                                        |
+
+The `code` tool gives the AI direct access to all Trustgrid API endpoints within a JavaScript sandbox. It can traverse relationships, aggregate data across nodes, or do anything the REST API supports — without risking writes or configuration changes.
+
+Codemode also includes all [node diagnostic tools](#tools-mcptools) from the `tools` group.
+
+The codemode scope requires broad read permissions. See [Authentication]({{<ref "docs/mcp/authentication">}}) for credential setup.
+
+### read (`/mcp/read`)
+
+The read group exposes individual Trustgrid API operations as discrete MCP tools — one tool per API endpoint, roughly.
+
+| Tool family      | Examples                                                                   | Description                                                                           |
+| ---------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Nodes            | `list_nodes`, `get_node`, `list_node_events`                               | Node inventory, full node records, and node event history.                            |
+| Clusters         | `list_clusters`, `get_cluster`, `list_cluster_vpn_routes`                  | Cluster inventory plus cluster VPN topology, routes, interfaces, and services.        |
+| Domains          | `get_domain`                                                               | Domain details and configuration.                                                     |
+| Alerts           | `list_alerts_v2`, `list_node_alerts_v2`                                    | Active alert lists at the org or node level.                                          |
+| Audit logs       | `tail_config_audit`, `tail_node_audit`                                     | Configuration change history and node audit trails.                                   |
+| Events           | `list_events`                                                              | Platform event stream for the org.                                                    |
+| VPN networks     | `list_node_vpn_networks`, `list_node_vpn_routes`, `list_node_vpn_services` | Node VPN topology, routes, interfaces, import/export routes, and services.            |
+| Virtual networks | `list_virtual_networks`, `list_network_routes`, `list_network_objects`     | Overlay network configuration including routes, objects, groups, and port forwarding. |
+| Flow logs        | `list_flow_logs`                                                           | Query network traffic flow logs with filters and pagination.                          |
+
+The read group requires a smaller set of OAuth scopes than codemode, making it suitable for tightly scoped service integrations.
+
+### tools (`/mcp/tools`)
+
+The tools group exposes discrete, live diagnostic tools that execute directly on Trustgrid nodes. Each tool invokes a service on the node and returns the live result.
+
+| Tool                     | Description                                                                                                    |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| `get_runtime_status`     | Node runtime status: running services, disk usage, memory, systemd unit states.                                |
+| `get_network_status`     | Node networking: interface states, link status, assigned IP addresses as seen by the node right now.           |
+| `get_dataplane_status`   | Gateway route connectivity: which gateway routes are up or down, including per-route status.                   |
+| `get_errors_status`      | Currently reported errors from the node. Pass `startupOnly: true` to filter to startup-phase errors only.      |
+| `test_tcp_connectivity`  | Attempt a TCP handshake from the node to a `host:port` target and report success or failure.                   |
+| `test_repo_connectivity` | Verify the node can reach its configured Trustgrid apt repositories. Reports per-repo success.                 |
+| `test_dns_health`        | Test DNS resolution against the node's configured resolvers. Returns per-server results.                       |
+| `test_gateway_latency`   | Run a latency trace from the node to a named gateway. Returns per-hop latency measurements.                    |
+| `test_packet_path`       | Simulate a TCP packet entering the node's virtual network and trace the path through routing and policy rules. |
+| `get_packet_capture`     | Run a bounded tcpdump on a node interface and return captured packet lines. Accepts BPF filter expressions.    |
+
+The tools group requires `nodes::read` plus service-specific scopes. The node does not need to be fully healthy to run most diagnostics — that's the point.
+
+## Combining groups
+
+Paths are combinable and order-independent. The server serves the union of all named groups:
+
+```
+https://mcp.trustgrid.io/mcp/codemode/read
+https://mcp.trustgrid.io/mcp/read/tools
+https://mcp.trustgrid.io/mcp/codemode/read/tools
+```
+
+Use the combined paths when your workflow needs both the `code` sandbox and direct per-resource tools, or when you want a single endpoint for a client that doesn't let you configure multiple servers.
+
+## Rate limits
+
+Limits apply per token across all requests:
+
+| Group    | Requests | Window     |
+| -------- | -------- | ---------- |
+| codemode | 10       | 60 seconds |
+| read     | 30       | 60 seconds |
+| tools    | 10       | 60 seconds |
+| default  | 30       | 60 seconds |
+
+When a limit is exceeded the server returns `429 Too Many Requests` with:
+
+- `Retry-After: <seconds>` — how long to wait before retrying
+- `X-RateLimit-Limit: <n>` — the limit for this bucket
+- `X-RateLimit-Remaining: 0` — remaining requests in the window
+- `X-RateLimit-Reset: <unix timestamp>` — when the window resets

--- a/content/en/docs/mcp/tools/index.md
+++ b/content/en/docs/mcp/tools/index.md
@@ -1,7 +1,6 @@
 ---
 title: "Available Tools"
 linkTitle: "Tools"
-weight: 20
 description: "Tool groups exposed by the Trustgrid MCP server and what each tool does."
 ---
 
@@ -16,7 +15,7 @@ The codemode group is the default when no path suffix is specified. It provides 
 | Tool       | Description                                                                                                                           |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `search`   | Semantic and keyword search across Trustgrid documentation. Returns relevant excerpts with source links.                              |
-| `describe` | Describe a codemode function. This provide the full signature to help your agent write valid code.                                    |
+| `describe` | Describe a codemode function. This provides the full signature to help your agent write valid code.                                   |
 | `code`     | Execute sandboxed JavaScript with access to the full read-only Trustgrid API. Use for custom queries, aggregations, and bulk lookups. |
 | `followUp` | Paginate through results from a prior `code` or `search` call.                                                                        |
 
@@ -24,7 +23,7 @@ The `code` tool gives the AI direct access to all Trustgrid API endpoints within
 
 Codemode also includes all [node diagnostic tools](#tools-mcptools) from the `tools` group.
 
-The codemode scope requires broad read permissions. See [Authentication]({{<ref "docs/mcp/authentication">}}) for credential setup.
+The codemode scope requires broad read permissions. See [Authentication]({{<relref "docs/mcp/authentication" >}}) for credential setup.
 
 ### read (`/mcp/read`)
 

--- a/content/en/docs/mcp/troubleshooting/index.md
+++ b/content/en/docs/mcp/troubleshooting/index.md
@@ -1,0 +1,99 @@
+---
+title: "Troubleshooting"
+linkTitle: "Troubleshooting"
+weight: 40
+description: "Common MCP server setup issues and how to fix them."
+---
+
+## Common issues
+
+### The server isn't appearing in my client
+
+**Check that your client supports HTTP transport.** Not all MCP clients support Streamable HTTP — some only support stdio (local process) connections. The Trustgrid MCP server is HTTP-only. Verify your client's MCP documentation.
+
+**Check the URL format.** The URL must include the path prefix:
+
+```
+https://mcp.trustgrid.io/mcp          ✓ correct
+https://mcp.trustgrid.io              ✗ missing /mcp
+https://mcp.trustgrid.io/mcp/         ✓ trailing slash is fine
+```
+
+**Check your domain.** If your organization has a tenant-specific endpoint (e.g., `mcp.acme.trustgrid.io`), use that rather than the default `mcp.trustgrid.io`. If you use the portal at <your-company-name>.trustgrid.io, your MCP endpoint is mcp.<your-company-name>.trustgrid.io.
+
+---
+
+### I'm getting 401 Unauthorized
+
+**Missing or malformed header.** Confirm the `Authorization` header is present and uses the correct format:
+
+```
+# API token
+Authorization: trustgrid-token YOUR_CLIENT_ID:YOUR_CLIENT_SECRET
+```
+
+A common mistake is using `Bearer` with an API token: `Bearer clientId:secret` won't work. Use `trustgrid-token clientId:secret`.
+
+**OAuth loop.** If the server returns a `WWW-Authenticate` challenge and your client doesn't handle OAuth, it may retry indefinitely. Configure a static token in the headers instead.
+
+---
+
+### I'm getting 403 Forbidden
+
+Your credentials are valid but lack permission for the requested operation. Check:
+
+- The API key was generated for the correct user account
+- The user account has appropriate permissions in the Trustgrid portal
+- You're using the correct endpoint path — `/mcp/tools` requires node service scopes that `/mcp/read` does not request
+
+---
+
+### Tools work but return errors for specific nodes
+
+**Node is offline.** Most diagnostic tools require the node to be reachable. If the node is disconnected from the control plane, `test_*` tools will time out or return an error.
+
+---
+
+### Rate limit errors (429)
+
+You're hitting the per-token request limit for the active group. Limits are:
+
+- codemode: 10 requests / 60 seconds
+- read: 30 requests / 60 seconds
+- tools: 10 requests / 60 seconds
+
+The response includes `Retry-After` header with the wait time in seconds. If you're hitting limits consistently, consider using the `read` group instead of `codemode` for read-heavy workflows, or split high-frequency queries across multiple credentials.
+
+---
+
+### OAuth won't complete / browser auth fails
+
+**Check the MCP URL.** OAuth flows redirect through `portal.trustgrid.io` or your tenant portal URL. If your network blocks the portal, the OAuth flow will fail. Use a static API token instead.
+
+**Check for cookie blockers.** Some browser extensions block third-party cookies and can interfere with OAuth callbacks. Try in a private window.
+
+---
+
+### The `code` tool says "not allowed" or isn't available
+
+The `code` tool is only in the **codemode** group (`/mcp/codemode` or `/mcp`). If you're connected to `/mcp/read` or `/mcp/tools`, the code sandbox isn't available. Change your client config to point at `/mcp` or `/mcp/codemode`.
+
+---
+
+## Submit feedback
+
+Found a bug, missing tool, or unexpected behavior? Open an issue at:
+
+**[github.com/trustgrid/mcp-features](https://github.com/trustgrid/mcp-features)**
+
+Helpful things to include in your report:
+
+- **Client name and version** — e.g., "Claude Code 1.2.3", "Cursor 0.45"
+- **Tool group / endpoint URL** — `/mcp/codemode`, `/mcp/read`, etc.
+- **The tool that failed** — the exact tool name (e.g., `test_tcp_connectivity`, `code`)
+- **What you asked for** — the prompt or tool call that triggered the issue
+- **What you got back** — the error message or unexpected response, including HTTP status codes if visible
+- **What you expected** — a brief description of the intended behavior
+- **Auth method** — OAuth or API token (don't include the actual credential)
+
+The more context you provide, the faster we can reproduce and fix it.

--- a/content/en/docs/mcp/troubleshooting/index.md
+++ b/content/en/docs/mcp/troubleshooting/index.md
@@ -1,7 +1,6 @@
 ---
 title: "Troubleshooting"
 linkTitle: "Troubleshooting"
-weight: 40
 description: "Common MCP server setup issues and how to fix them."
 ---
 
@@ -19,7 +18,7 @@ https://mcp.trustgrid.io              ✗ missing /mcp
 https://mcp.trustgrid.io/mcp/         ✓ trailing slash is fine
 ```
 
-**Check your domain.** If your organization has a tenant-specific endpoint (e.g., `mcp.acme.trustgrid.io`), use that rather than the default `mcp.trustgrid.io`. If you use the portal at <your-company-name>.trustgrid.io, your MCP endpoint is mcp.<your-company-name>.trustgrid.io.
+**Check your domain.** If your organization has a tenant-specific endpoint (e.g., `mcp.acme.trustgrid.io`), use that rather than the default `mcp.trustgrid.io`. If you use the portal at `your-company-name.trustgrid.io`, your MCP endpoint is `mcp.your-company-name.trustgrid.io`.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a new MCP section under Documentation in the docs sidebar
- include public MCP pages for overview, authentication, installation, tools, and troubleshooting
- keep the change isolated from unrelated local edits in the working tree
