### PR TITLE
Document AWS cluster IP failover is single-AZ only

### DIFF
--- a/content/en/tutorials/deployments/deploy-aws/ip-failover/index.md
+++ b/content/en/tutorials/deployments/deploy-aws/ip-failover/index.md
@@ -61,6 +61,8 @@ The source/destination check must be disabled on each cluster member's data ENI.
 
 The cluster IP must be an unused private IP in the same subnet as the cluster members' data NICs. It is not an Elastic IP — it is a secondary private IPv4 address within the VPC CIDR.
 
+{{<alert color="warning">}}**Both cluster members must reside in the same Availability Zone.** A secondary private IP must fall within the ENI's subnet CIDR, and an AWS subnet is bound to a single AZ. Because both members share the data subnet, they share its AZ. Cluster IP failover cannot float an IP across AZs — for a cross-AZ HA topology, use [route failover]({{<relref "route-failover">}}) instead.{{</alert>}}
+
 ## Configuration
 
 ### Portal


### PR DESCRIPTION
## What

Adds a `warning` callout to the [AWS Cluster IP Failover tutorial](https://docs.trustgrid.io/tutorials/deployments/deploy-aws/ip-failover/) under **Subnet IP Availability**, stating both cluster members must reside in the same Availability Zone.

## Why

Cluster IP failover floats a secondary private IP between member ENIs via `AssignPrivateIpAddresses`. A secondary private IP must fall within the ENI's subnet CIDR, and an AWS subnet is bound to a single AZ, so both members must share the subnet and the AZ. Cross-AZ cluster IP failover is not possible with this mechanism. The callout points cross-AZ HA topologies at route failover instead.

Real customer question — being explicit prevents users designing cross-AZ HA around this feature.

Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)