### PR TITLE
Add CVE scanning and vulnerability management page

### DIFF
--- a/content/en/getting-started/security/cve-scanning.md
+++ b/content/en/getting-started/security/cve-scanning.md
@@ -1,0 +1,29 @@
+---
+linkTitle: "CVE Scanning"
+title: "CVE Scanning and Vulnerability Management"
+tags: ["security", "overview"]
+description: >
+    How Trustgrid evaluates CVEs, applies package updates, and why agentless scan results should be interpreted carefully.
+---
+
+## How Trustgrid Evaluates CVEs
+
+Trustgrid continuously monitors CVE disclosures and evaluates each against the actual configuration, access controls, and mitigations present in the platform. Most CVEs flagged by automated scanners are not exploitable on Trustgrid nodes. Architectural controls, restricted network access, and a limited attack surface keep them out of reach.
+
+When a CVE is genuinely exploitable in our environment, Trustgrid coordinates with affected customers to define mitigation steps and fast-tracks a release with the appropriate packages.
+
+## Package Updates and Release Cadence
+
+Trustgrid nodes use curated mirrors of the Ubuntu package repositories. These mirrors are updated for major releases and, when necessary, for security-focused minor releases issued between majors. Routine bug-fix minor releases do not update the mirror.
+
+Each release's mirror date is published in the [Release Notes]({{<relref "release-notes/node" >}}). A node applies all security packages available as of that date the next time it runs its scheduled update.
+
+To reduce reported vulnerabilities, update nodes to the latest release. The latest release always carries the most current mirror.
+
+Scheduling node updates is the [Customer]({{<relref "help-center/support-responsibility-matrix#customer" >}})'s responsibility, in accordance with their change management procedures.
+
+## Interpreting Agentless Scan Results
+
+Agentless scanners infer installed package versions remotely and may not accurately reflect what is actually present on a device. Because Trustgrid nodes do not permit direct remote access, agentless scanning is the only method available to end users, so interpret scan results carefully.
+
+If a scan reports a package version that predates the mirror date of the node's current release, this is likely a reporting artifact. The system is patched. Refer to the release notes for the current mirror date before drawing conclusions from scan output.

--- a/content/en/help-center/support-responsibility-matrix/index.md
+++ b/content/en/help-center/support-responsibility-matrix/index.md
@@ -47,6 +47,7 @@ Site with Trustgrid node(s) deployed and managed by the End-User.
 | Issue Type                                                      | Trustgrid           | Customer               | End-User               |
 | --------------------------------------------------------------- | ------------------- | ---------------------- | ---------------------- |
 | Trustgrid software or operating system issues                   | Full                | None                   | None                   |
+| Upgrading the Node<sup>2</sup>                                   | None<sup>3</sup>    | Full                   | None                   |
 | Hardware appliance | Shared | Shared | None |
 | Control Plane Connectivity                                      | Shared              | Shared - Customer Site | Shared - End-User Site |
 | Data Plane Connectivity                                         | Limited<sup>1</sup> | Shared                 | Shared                 |
@@ -59,6 +60,10 @@ Site with Trustgrid node(s) deployed and managed by the End-User.
 ---
 
 <sup>1</sup>Trustgrid can work with the Customer and End-User to confirm that the Trustgrid system is working as expected and provide additional information to aid in troubleshooting.
+
+<sup>2</sup>Upgrading the Trustgrid Node version also updates the operating system's security packages.
+
+<sup>3</sup>Customers who purchase Trustgrid Professional Services may have Trustgrid perform fleet-wide upgrades. The Customer remains responsible for scheduling them.
 
 ### Tier One Support
 


### PR DESCRIPTION
Closes #753.

## What

Adds a security sub-page under `/getting-started/security` documenting Trustgrid's CVE evaluation and remediation process:

- **How Trustgrid Evaluates CVEs** — continuous monitoring, why most scanner-flagged CVEs aren't exploitable, and how genuinely exploitable CVEs are handled.
- **Package Updates and Release Cadence** — curated Ubuntu mirrors, when mirrors update, and the recommendation to run the latest release. Links "Release Notes" to the [node release notes](https://docs.trustgrid.io/release-notes/node/).
- **Interpreting Agentless Scan Results** — why agentless scan output against Trustgrid nodes can be a reporting artifact rather than an unpatched system.

## Also

Updates the **Support Responsibility Matrix** with an "Upgrading the Node" row:

- Footnote clarifying that upgrading the Node version also updates the OS security packages.
- Footnote noting the Trustgrid Professional Services fleet-wide upgrade exception, with the Customer still responsible for scheduling.

The CVE page references the **Customer** role and links to the responsibility matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)