### PR TITLE
Rework JVM memory and GC guidance for network engineers

### DIFF
--- a/content/en/docs/nodes/appliances/advanced/index.md
+++ b/content/en/docs/nodes/appliances/advanced/index.md
@@ -16,7 +16,6 @@ The Config Options panel allows customizing various advanced settings for the no
 After changing a setting click the Save button. **Some changes may require a node restart to take effect.**
 
 ## JVM Memory
-{{<tgimg src="jvm-memory.png" width="40%" caption="Java Virtual Machine (JVM) memory settings">}}
 
 ### Execute Garbage Collection
 This button forces the Java process to clean up memory and execute garbage collection. This is useful if you are seeing memory issues and want to force the JVM to clean up memory.
@@ -25,6 +24,16 @@ This button forces the Java process to clean up memory and execute garbage colle
 
 ### Memory Settings
 
-The JVM Memory panel allows changing the [default JVM settings]({{<relref "/help-center/kb/default-settings/jvm">}}) for the node process. 
-
+The JVM Memory panel allows changing the default JVM settings for the node process. See the [JVM Knowledge Base article]({{<relref "/help-center/kb/default-settings/jvm" >}}) for more information on the default settings and recommendations for changing them.
+{{<fields>}}
+{{<field "Minimum Memory" >}} The starting amount of memory the JVM process will consume for heap usage. {{</field>}}
+{{<field "Maximum Memory" >}} The maximum amount of memory the JVM process can use for heap usage. {{</field>}}
+{{<field "Garbage Collector" >}} 
+<ul>
+  <li>Default (Parallel GC)</li>
+  <li>G1 GC</li>
+</ul>
+ {{</field>}}
+{{</fields>}}
 **The node must be restarted for any change to be effective.**
+{{<tgimg src="jvm-memory.png" width="40%" caption="Java Virtual Machine (JVM) memory settings">}}

--- a/content/en/docs/nodes/appliances/advanced/index.md
+++ b/content/en/docs/nodes/appliances/advanced/index.md
@@ -35,5 +35,5 @@ The JVM Memory panel allows changing the default JVM settings for the node proce
 </ul>
  {{</field>}}
 {{</fields>}}
-**The node must be restarted for any change to be effective.**
+**The node must be restarted for any change to take effect.**
 {{<tgimg src="jvm-memory.png" width="40%" caption="Java Virtual Machine (JVM) memory settings">}}

--- a/content/en/help-center/kb/default-settings/jvm/index.md
+++ b/content/en/help-center/kb/default-settings/jvm/index.md
@@ -10,7 +10,7 @@ These settings only apply to appliance-based Trustgrid nodes
 {{</alert>}}
 
 ## Memory Settings
-The Java Virtual Machine (JVM) is responsible for managing the memory used by the Trustgrid service on appliances. Two key parameters that control this memory management are the minimum (min) and maximum (max) memory values.
+The Java Virtual Machine (JVM) is responsible for managing the memory used by the Trustgrid service on appliances. Two key parameters that control this memory management are the minimum (min) and maximum (max) memory values. These settings can be adjusted under [Advanced > JVM]({{<relref "/docs/nodes/appliances/advanced#memory-settings" >}}) in the Trustgrid Management Portal.
 
 1. **Minimum Memory:** This is the initial memory allocation for the JVM. When your Java application starts, the JVM allocates this amount of memory right away. It's like setting a base size for the memory footprint of your application.
 
@@ -42,6 +42,3 @@ There are multiple different garbage collectors, each with its own strategy and 
 - Handling Large Memory: Efficient for applications with large heaps.
 
 Despite these advantages, Trustgrid has not yet been able to see significant performance improvements by switching to G1 over Parallel GC in most customer environments. Unless you are experiencing specific performance issues, we recommend leaving the default Parallel GC.
-
-
-{{<alert color="info">}}Contact Trustgrid support if you need to adjust these settings{{</alert>}}

--- a/content/en/help-center/kb/default-settings/jvm/index.md
+++ b/content/en/help-center/kb/default-settings/jvm/index.md
@@ -10,35 +10,58 @@ These settings only apply to appliance-based Trustgrid nodes
 {{</alert>}}
 
 ## Memory Settings
-The Java Virtual Machine (JVM) is responsible for managing the memory used by the Trustgrid service on appliances. Two key parameters that control this memory management are the minimum (min) and maximum (max) memory values. These settings can be adjusted under [Advanced > JVM]({{<relref "/docs/nodes/appliances/advanced#memory-settings" >}}) in the Trustgrid Management Portal.
+The Java Virtual Machine (JVM) is responsible for managing the memory used by the Trustgrid service on appliances. Two key parameters that control this memory management are the minimum (min) and maximum (max) memory values. These settings can be adjusted under [Advanced > JVM Memory]({{<relref "/docs/nodes/appliances/advanced#memory-settings" >}}) in the Trustgrid Management Portal.
 
-1. **Minimum Memory:** This is the initial memory allocation for the JVM. When your Java application starts, the JVM allocates this amount of memory right away. It's like setting a base size for the memory footprint of your application.
+1. **Minimum Memory:** This is the initial memory allocation for the JVM. When the Trustgrid service starts, the JVM allocates this amount of memory right away. It's like setting a base size for the service's memory footprint.
 
-2. **Maximum Memory:** This is the maximum amount of memory the JVM is allowed to use. If your application needs more memory than the initial amount (set by min), it will continue to use more up to this maximum limit.
+2. **Maximum Memory:** This is the maximum amount of memory the JVM is allowed to use. If the Trustgrid service needs more memory than the initial amount (set by Minimum), it will continue to use more up to this maximum limit.
 
 
 |Parameter| Default | Recommendations|
 |---|---|---|
 |Minimum | 512MB | 512MB is the recommended smallest value | 
-|Maximum | 1GB | - Start with the total available system memory <br>- Subtract ~ 1G for OS and other processes <br> - If running containers or virtual machines on the appliance subtract their expected memory usage <br> - Set the value so that it does not exceed about 75% of remaining memory|
+|Maximum | 1GB | - The 1GB default runs reliably on appliances with as little as 2GB of total memory <br>- To raise it, see [Suggested Maximum Memory by Total System Memory](#suggested-maximum-memory-by-total-system-memory) below|
 
-### Why Increase the Max Memory?
+### Suggested Maximum Memory by Total System Memory
 
-- **Handling Larger Workloads:** If your Trustgrid appliance is managing a large number of flows or processing large amounts of data, increasing the maximum memory can help accommodate spikes in memory usage without triggering garbage collection as frequently.
+These are starting points assuming the appliance isn't running any containers.
 
-- **Performance Optimization:** Increasing the max memory can reduce the frequency of garbage collection (a process that frees up memory by removing unused objects), which can improve performance.
+| Total System Memory | Suggested Maximum Memory | % of Total |
+|---|---|---|
+| 2GB | 1GB (default) | 50% |
+| 4GB | 2GB | 50% |
+| 8GB | 5GB | 62% |
+| 16GB | 11GB | 69% |
+| 32GB | 22GB | 69% |
 
-Remember, while increasing max memory can help, it's important to balance it with the available system resources to avoid starving other processes or causing system-wide issues.
+If the appliance also runs containers, subtract the sum of **all configured containers'** [Memory Max]({{<relref "docs/nodes/appliances/containers#resource-limits" >}}) limits from the suggested value above. If the result falls below 1GB, use a larger appliance instead. For sizes not listed, cap Maximum Memory at 50-70% of total system memory, trending toward the higher end on larger appliances.
+
+### A Note on G1 and the Memory Usage Chart
+
+{{<alert color="info">}}
+Trustgrid appliances run the G1 garbage collector by default, which doesn't return memory to the operating system once it's allocated during normal operation. Because of this, the memory usage shown on the appliance [Overview]({{<relref "docs/nodes/appliances/overview#stats" >}}) can stay high even when the appliance is idle. A high, flat reading on its own isn't a sign of a problem. Size **Maximum Memory** for what you're comfortable committing long-term, not as a soft ceiling.
+{{</alert>}}
+
+### Diagnosing a Suspected Memory Issue
+
+If the node is processing traffic normally and you have no other signs of trouble, leave the defaults alone. If you want to check further, look at the [JVM Heap metric]({{<relref "docs/nodes/appliances/metrics#jvm-heap" >}}) for one of these patterns:
+
+- **Heap stays pinned high** (above 80% of Maximum Memory) and doesn't drop after a GC run. This can indicate the appliance genuinely needs more memory.
+- **Heap rapidly fills and empties** in a repeating sawtooth pattern. This can indicate garbage collection is running very frequently, which adds overhead.
+
+If you see either pattern:
+
+1. [Force a GC run]({{<relref "docs/nodes/appliances/advanced#execute-garbage-collection" >}}) and watch the heap for a few minutes afterward.
+2. If it stays pinned high, or keeps sawtoothing under normal traffic, increase **Maximum Memory** using the [sizing guidance above](#suggested-maximum-memory-by-total-system-memory).
+3. Restart the service only as a last resort. The Java process can also request memory outside the heap for certain activities, and a restart is the only way to release that.
 
 ## Java Garbage Collection
 The Java Garbage Collection system:
 - Automatically frees up memory by removing unused objects.
 - Essential for managing memory in the JVM.
 
-There are multiple different garbage collectors, each with its own strategy and performance characteristics. The default garbage collector on Trustgrid appliances is the Parallel GC.  Optionally, we also support using the G1 Garbage Collector.
+Trustgrid appliances run **G1 GC** by default. G1 offers more predictable, shorter garbage collection pauses than the alternative Parallel GC. That matters for nodes handling live network traffic: Parallel GC's collections are stop-the-world and can introduce latency or drop packets while they run. Unless you're troubleshooting a specific issue, leave the Garbage Collector setting on G1.
 
-### Switching to G1 Garbage Collector
-- Better Performance: G1 offers more predictable garbage collection pauses, reducing latency.
-- Handling Large Memory: Efficient for applications with large heaps.
-
-Despite these advantages, Trustgrid has not yet been able to see significant performance improvements by switching to G1 over Parallel GC in most customer environments. Unless you are experiencing specific performance issues, we recommend leaving the default Parallel GC.
+{{<alert color="info">}}
+The Garbage Collector dropdown in the portal labels the Parallel GC option "Default." That label is left over from an earlier release. G1 GC is what Trustgrid appliances actually run out of the box.
+{{</alert>}}

--- a/content/en/help-center/kb/default-settings/jvm/index.md
+++ b/content/en/help-center/kb/default-settings/jvm/index.md
@@ -39,21 +39,21 @@ If the appliance also runs containers, subtract the sum of **all configured cont
 ### A Note on G1 and the Memory Usage Chart
 
 {{<alert color="info">}}
-Trustgrid appliances run the G1 garbage collector by default, which doesn't return memory to the operating system once it's allocated during normal operation. Because of this, the memory usage shown on the appliance [Overview]({{<relref "docs/nodes/appliances/overview#stats" >}}) can stay high even when the appliance is idle. A high, flat reading on its own isn't a sign of a problem. Size **Maximum Memory** for what you're comfortable committing long-term, not as a soft ceiling.
+Trustgrid appliances run the G1 garbage collector by default. G1's normal, incremental collections don't reclaim memory the Java process allocates outside the heap, such as Netty's direct buffers, so that usage builds up during normal operation. Because of this, the memory usage shown on the appliance [Overview]({{<relref "docs/nodes/appliances/overview#stats" >}}) can stay high even when the appliance is idle. A high, flat reading on its own isn't a sign of a problem. Size **Maximum Memory** for what you're comfortable committing long-term, not as a soft ceiling.
 {{</alert>}}
 
 ### Diagnosing a Suspected Memory Issue
 
 If the node is processing traffic normally and you have no other signs of trouble, leave the defaults alone. If you want to check further, look at the [JVM Heap metric]({{<relref "docs/nodes/appliances/metrics#jvm-heap" >}}) for one of these patterns:
 
-- **Heap stays pinned high** (above 80% of Maximum Memory) and doesn't drop after a GC run. This can indicate the appliance genuinely needs more memory.
+- **Heap stays pinned high** (above 80% of Maximum Memory) and doesn't drop after a forced GC run. This can indicate the appliance genuinely needs more memory.
 - **Heap rapidly fills and empties** in a repeating sawtooth pattern. This can indicate garbage collection is running very frequently, which adds overhead.
 
 If you see either pattern:
 
-1. [Force a GC run]({{<relref "docs/nodes/appliances/advanced#execute-garbage-collection" >}}) and watch the heap for a few minutes afterward.
+1. [Force a GC run]({{<relref "docs/nodes/appliances/advanced#execute-garbage-collection" >}}) and watch the heap for a few minutes afterward. A full GC reclaims off-heap allocations that build up during normal operation, so this gives you an accurate baseline instead of the inflated reading a regular, incremental collection leaves behind.
 2. If it stays pinned high, or keeps sawtoothing under normal traffic, increase **Maximum Memory** using the [sizing guidance above](#suggested-maximum-memory-by-total-system-memory).
-3. Restart the service only as a last resort. The Java process can also request memory outside the heap for certain activities, and a restart is the only way to release that.
+3. Restart the service only if the issue persists after the steps above.
 
 ## Java Garbage Collection
 The Java Garbage Collection system:


### PR DESCRIPTION
Reworks the JVM KB page for a network-engineer audience (no Xmx/Xms jargon), fixes the Maximum Memory sizing guidance to reflect real-world 2GB appliance behavior, corrects the documented GC default to G1 (matching actual appliance behavior, despite the portal dropdown still labeling ParallelGC as "Default"), and adds a diagnosis flow for suspected memory issues (pinned-high heap vs. rapid fill/empty sawtooth).

Closes #758
Closes #736