### PR TITLE
docs: add July 2026 cloud release notes

### DIFF
--- a/content/en/release-notes/cloud/2026-07/index.md
+++ b/content/en/release-notes/cloud/2026-07/index.md
@@ -1,0 +1,11 @@
+---
+title: "July 2026 Cloud Release Notes"
+linkTitle: "July 2026"
+date: 2026-07-09
+description: "July 2026 Cloud Release Notes"
+type: docs
+---
+
+## July 9, 2026 - Minor Release
+### Other Improvements and Fixes
+- Resolves an issue that prevented users from changing [JVM Memory and Garbage Collector]({{<relref "docs/nodes/appliances/advanced#jvm-memory">}}) settings.


### PR DESCRIPTION
## Summary
- Adds the July 2026 cloud release notes page
- Minor release entry: fixes an issue that prevented users from changing JVM Memory and Garbage Collector settings, linking to the relevant advanced settings doc

## Test plan
- [ ] Netlify preview build succeeds
- [ ] Page renders correctly under Release Notes > Cloud