### PR TITLE
Add July 29, 2026 cloud release notes

### DIFF
--- a/content/en/release-notes/cloud/2026-07/index.md
+++ b/content/en/release-notes/cloud/2026-07/index.md
@@ -6,6 +6,10 @@ description: "July 2026 Cloud Release Notes"
 type: docs
 ---
 
+## July 29, 2026 - Minor Release
+### Other Improvements and Fixes
+- Updated underlying libraries across several control plane components to address reported security vulnerabilities.
+
 ## July 9, 2026 - Minor Release
 ### Other Improvements and Fixes
 - Resolves an issue that prevented users from changing [JVM Memory and Garbage Collector]({{<relref "docs/nodes/appliances/advanced#jvm-memory">}}) settings.


### PR DESCRIPTION
Adds a July 29, 2026 minor release section to the July 2026 cloud release notes, noting dependency security updates across control plane components.

Phrasing follows the precedent set in the 2026-04 cloud notes: no component names or CVE IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)