### PR TITLE
docs: document Speed Test tool and stats data resolution

### DIFF
--- a/content/en/docs/nodes/appliances/interfaces/index.md
+++ b/content/en/docs/nodes/appliances/interfaces/index.md
@@ -28,6 +28,19 @@ Used in configurations with more than one interface for local network connectivi
 #### VLAN Subinterface 
  Virtual under a physical LAN interface that will apply a VLAN tag to traffic
 
+## Tools
+
+The **Interface Tools** section provides diagnostic tools scoped to the interface selected in the dropdown above.
+
+{{<tgimg src="/tutorials/interface-tools/tcp-port-test/network-tools.png" width="90%" caption="Interface Tools section">}}
+
+- [Speed Test]({{<relref "/tutorials/interface-tools/speed-test">}}) - Measure upload and download throughput between the node and the Trustgrid cloud over the selected interface.
+- [Sniff Traffic]({{<relref "/tutorials/interface-tools/sniff-interface-traffic">}}) - Monitor traffic on the interface in realtime.
+- [Interface TCP Port Test]({{<relref "/tutorials/interface-tools/tcp-port-test">}}) - Test layer 4 TCP connectivity to a target IP address and port.
+- [ARP Ping]({{<relref "/tutorials/interface-tools/arping">}}) - Send an ARP request to a specific IP address on the interface.
+- [AWS Interface ENA Stats]({{<relref "/tutorials/interface-tools/aws-interface-stats">}}) - View AWS ENA statistics to troubleshoot network performance on AWS-hosted nodes.
+- [AWS Route Tables]({{<relref "/tutorials/interface-tools/aws-route-tables">}}) - Query AWS route tables associated with the interface.
+- [Traffic Capture]({{<relref "/tutorials/interface-tools/traffic-capture">}}) - Capture interface traffic to a pcap file for analysis.
 
 ## Configuration
 

--- a/content/en/docs/nodes/appliances/overview/index.md
+++ b/content/en/docs/nodes/appliances/overview/index.md
@@ -50,7 +50,9 @@ The **Showing data for** time window controls how many data points the graphs pl
 | 1 Month | 6 hours |
 
 {{<alert title="Note" color="info">}}
-CPU, memory, disk, heap, uptime, gateway active/available, and local flows are point-in-time readings taken at the plotted interval, not averages over that interval.
+At 1 minute resolution (the **1 Hour** and **2 Hours** windows), CPU, memory, disk, heap, uptime, gateway active/available, and local flows are point-in-time readings taken at the plotted interval, not averages over that interval.
+
+At coarser resolutions (**6 Hours** and longer), these same metrics are the mean/average across the interval rather than a point-in-time reading.
 
 Traffic stats such as bytes sent/received, gateway bytes, and resets are deltas against the previous interval's cumulative counter, rather than point-in-time readings.
 {{</alert>}}

--- a/content/en/docs/nodes/appliances/overview/index.md
+++ b/content/en/docs/nodes/appliances/overview/index.md
@@ -36,3 +36,21 @@ shows new and active flows, across all VPNs and for the selected virtual network
 shows aggregate TCP packet and state statistics across all interfaces
 {{</field >}}
 {{</fields>}}
+
+### Data Resolution
+
+The **Showing data for** time window controls how many data points the graphs plot, not how often stats are collected. As the time window grows, each plotted point represents a coarser interval:
+
+| Time Window | Interval Between Points |
+|---|---|
+| 1 Hour / 2 Hours | 1 minute |
+| 6 Hours | 2 minutes |
+| 12 Hours / 24 Hours | 5 minutes |
+| 1 Week | 60 minutes |
+| 1 Month | 6 hours |
+
+{{<alert title="Note" color="info">}}
+CPU, memory, disk, heap, uptime, gateway active/available, and local flows are point-in-time readings taken at the plotted interval, not averages over that interval.
+
+Traffic stats such as bytes sent/received, gateway bytes, and resets are deltas against the previous interval's cumulative counter, rather than point-in-time readings.
+{{</alert>}}

--- a/content/en/docs/nodes/appliances/overview/index.md
+++ b/content/en/docs/nodes/appliances/overview/index.md
@@ -50,7 +50,7 @@ The **Showing data for** time window controls how many data points the graphs pl
 | 1 Month | 6 hours |
 
 {{<alert title="Note" color="info">}}
-At 1 minute resolution (the **1 Hour** and **2 Hours** windows), CPU, memory, disk, heap, uptime, gateway active/available, and local flows are point-in-time readings taken at the plotted interval, not averages over that interval.
+At 1 minute resolution (the **1 Hour** and **2 Hours** windows), CPU, memory, disk, uptime, and gateway active/available are point-in-time readings taken at the plotted interval, not averages over that interval.
 
 At coarser resolutions (**6 Hours** and longer), these same metrics are the mean/average across the interval rather than a point-in-time reading.
 

--- a/content/en/tutorials/interface-tools/speed-test/index.md
+++ b/content/en/tutorials/interface-tools/speed-test/index.md
@@ -1,0 +1,22 @@
+---
+title: "Speed Test"
+linkTitle: "Speed Test"
+description: "Measure upload and download throughput between a node and the Trustgrid cloud over a specific interface"
+---
+
+{{% pageinfo %}}
+The Speed Test tool measures upload and download throughput between the node and the Trustgrid cloud over a selected local interface. Because it runs directly from the node against the same control-plane gatekeeper endpoint the node normally uses for management traffic, it's useful for confirming real-world achievable bandwidth on a given interface, independent of any VPN or virtual network overhead.
+{{% /pageinfo %}}
+
+## Usage
+
+1. Login to the Trustgrid portal and navigate to the Node you want to test.
+1. Select **Interfaces** under the **Network** section, then use the interface dropdown to select the interface you want to test.
+1. In the **Interface Tools** section, click the **Speed Test** button. {{<tgimg src="/tutorials/interface-tools/tcp-port-test/network-tools.png" width="90%" caption="Selecting Speed Test">}}
+1. Click **GO** to start the test.
+1. The test first measures download throughput, then upload throughput, animating a gauge for each phase as the measured speed comes in.
+1. When the test completes, the results panel shows the peak download and upload speeds achieved. Click **GO** again to re-run the test.
+
+## How It Works
+
+Speed Test transfers data between the node and Trustgrid's cloud gatekeeper - the node's control-plane endpoint - rather than an arbitrary internet target. The download and upload legs run one after the other, each over the interface selected on the Interfaces page, so the result reflects that interface's actual path to the Trustgrid cloud rather than aggregate throughput across all interfaces.


### PR DESCRIPTION
## Summary
- Add a Speed Test tutorial page under `tutorials/interface-tools/`, documenting the node → Interfaces → Interface Tools → Speed Test flow and how the tool measures throughput against the node's Trustgrid cloud gatekeeper endpoint.
- Add a **Tools** section to the Interfaces doc page (`docs/nodes/appliances/interfaces`) linking to all interface tools (Speed Test plus the six existing ones).
- Add a **Data Resolution** section to the node Overview doc page documenting the time-window → sample-interval mapping and point-in-time vs. delta metric behavior.

AN-230

## Test plan
- [ ] Built locally with `hugo` and confirmed all three pages render and all links resolve
- [ ] Jack to review/test locally before merge
